### PR TITLE
Fixing Non-standard file/directory found at top level: RPackVGL/data-raw

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
 ^RPackVGL\.Rproj$
 ^\.Rproj\.user$
+^data-raw$
+^RpackVGL$


### PR DESCRIPTION
I added "RPackVGL" and "data-raw" folders to .Rbuildignore to fix a warning 